### PR TITLE
Allow assets with libraries with dotted names.

### DIFF
--- a/lib/qxcompiler/ResourceManager.js
+++ b/lib/qxcompiler/ResourceManager.js
@@ -319,7 +319,7 @@ module.exports = qx.Class.define("qxcompiler.ResourceManager", {
 
       for (var i = 0; i < srcPaths.length; i++) {
         var srcPath = srcPaths[i];
-        var libraryName = srcPath.match(/^(\w+)/)[0];
+        var libraryName = srcPath.match(/^([\w\.]+)/)[0];
         var libraryData = db.resources[libraryName];
         var pos = srcPath.indexOf('*');
         if (pos > -1) {
@@ -416,5 +416,3 @@ module.exports = qx.Class.define("qxcompiler.ResourceManager", {
     }
   }
 });
-
-


### PR DESCRIPTION
Like: qxc.promise - source/resource/qxc.promise.

Signed-off-by: Rene Jochum <rene@jochums.at>