### PR TITLE
Add option to copy resources in source builds.

### DIFF
--- a/lib/qxcompiler/targets/SourceTarget.js
+++ b/lib/qxcompiler/targets/SourceTarget.js
@@ -37,6 +37,16 @@ require("./Target");
 module.exports = qx.Class.define("qxcompiler.targets.SourceTarget", {
   extend: qxcompiler.targets.Target,
 
+  properties: {
+    /**
+     * Whether to copy resources in source builds.
+     */
+    copyResources: {
+      check: "Boolean",
+      init: false
+    }
+  },
+
   members: {
     /*
      * @Override
@@ -45,22 +55,58 @@ module.exports = qx.Class.define("qxcompiler.targets.SourceTarget", {
       var t = this;
       var application = compileInfo.application;
 
-      this.getAnalyser().getLibraries().forEach(function (library) {
-        var targetUri = t.getTargetUri()||"";
-        if (targetUri && !targetUri.match(/\/$/))
-          targetUri += "/";
-        var libraryUri = t.getUri(library.getNamespace());
-        if (!libraryUri) {
-          libraryUri = path.relative(t.getOutputDir() + "/", library.getRootDir()) + "/";
-        }
 
-        compileInfo.configdata.libraries[library.getNamespace()] = {
-          sourceUri: targetUri + "transpiled/",
-          resourceUri: targetUri + libraryUri + "/" + library.getResourcePath()
+      if (!this.getCopyResources()) {
+        this.getAnalyser().getLibraries().forEach(function (library) {
+          var targetUri = t.getTargetUri()||"";
+          if (targetUri && !targetUri.match(/\/$/))
+            targetUri += "/";
+          var libraryUri = t.getUri(library.getNamespace());
+          if (!libraryUri) {
+            libraryUri = path.relative(t.getOutputDir() + "/", library.getRootDir()) + "/";
+          }
+
+          compileInfo.configdata.libraries[library.getNamespace()] = {
+            sourceUri: targetUri + "transpiled/",
+            resourceUri: targetUri + libraryUri + "/" + library.getResourcePath()
+          };
+        });
+
+        this.base(arguments, compileInfo, cb);
+      } else {
+        var _arguments = arguments;
+        var libraries = this.getAnalyser().getLibraries();
+        var libraryLookup = {};
+        libraries.forEach(function(library) {
+          libraryLookup[library.getNamespace()] = library;
+
+          var targetUri = t.getTargetUri()||"";
+          if (targetUri && !targetUri.match(/\/$/))
+            targetUri += "/";
+
+          compileInfo.configdata.libraries[library.getNamespace()] = {
+            sourceUri: targetUri + "transpiled/",
+            resourceUri: "resource"
+          };
+        });
+
+        var queue = async.queue(
+            function(asset, cb) {
+              var library = libraryLookup[asset.libraryName];
+              qxcompiler.files.Utils.sync(
+                  library.getRootDir() + "/" + library.getResourcePath() + "/" + asset.filename,
+                  t.getOutputDir() + "/resource/" + asset.filename,
+                  cb);
+            },
+            100
+        );
+        queue.drain = function(err) {
+          if (err)
+            return cb(err);
+          t.base(_arguments, compileInfo, cb);
         };
-      });
-
-      this.base(arguments, compileInfo, cb);
+        queue.push(compileInfo.assets);
+      }
     },
 
     /*
@@ -71,6 +117,3 @@ module.exports = qx.Class.define("qxcompiler.targets.SourceTarget", {
     }
   }
 });
-
-
-


### PR DESCRIPTION
This makes serving the content with grunt-contrib-connect easier.

Signed-off-by: Rene Jochum <rene@jochums.at>